### PR TITLE
Add task machine template and wire into planner

### DIFF
--- a/scripts/pipeline_task_machine.sh
+++ b/scripts/pipeline_task_machine.sh
@@ -16,6 +16,14 @@ OUTPUT_DIR="output"
 mkdir -p "$OUTPUT_DIR"
 
 PLAN_FILE="$OUTPUT_DIR/task_machine_plan.md"
+TEMPLATE_FILE="templates/task_machine_multirole.md"
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "ERROR: Required task template '$TEMPLATE_FILE' not found."
+  exit 1
+fi
+
+PLANNER_TEMPLATE_CONTENT="$(cat "$TEMPLATE_FILE")"
 
 #############################################
 # Helper: Mandatory output enforcement
@@ -41,7 +49,7 @@ rm -f "$PLAN_FILE"
 
 echo "Running Task Machine Planner..."
 
-PLANNER_PROMPT="You are the **TASK MACHINE PLANNER** in a two-stage pipeline.\n\nMANDATORY BEHAVIOR:\n- Read the user's high-level goal and constraints.\n- Produce a markdown document written to: \`${PLAN_FILE}\`.\n- The document MUST contain two sections: \n  1. \`## Context\` summarizing the overall objective.\n  2. \`## Chronologic Task List\` describing step-by-step tasks.\n- Every task MUST be self-contained, independent, and formatted as a markdown checkbox line in chronological order, e.g. \`- [ ] Task name — clear, actionable instructions...\`.\n- Include all details needed to execute each task without referencing other tasks.\n- Do NOT mark any task as completed.\n- You MUST use MCP tools to write the document and MUST NOT finish without creating \`${PLAN_FILE}\`.\n\nTASK:\nCreate the plan for the following goal:\n\n${TASK_CONTEXT}"
+PLANNER_PROMPT="You are the **TASK MACHINE PLANNER** in a two-stage pipeline.\n\nMANDATORY BEHAVIOR:\n- Read the user's high-level goal and constraints.\n- Produce a markdown document written to: \`${PLAN_FILE}\`.\n- The document MUST contain two sections: \n  1. \`## Context\` summarizing the overall objective.\n  2. \`## Chronologic Task List\` describing step-by-step tasks.\n- Every task MUST be self-contained, independent, and formatted as a markdown checkbox line in chronological order, e.g. \`- [ ] Task name — clear, actionable instructions...\`.\n- Include all details needed to execute each task without referencing other tasks.\n- Do NOT mark any task as completed.\n- You MUST use MCP tools to write the document and MUST NOT finish without creating \`${PLAN_FILE}\`.\n- You MUST incorporate the provided task template verbatim and ensure each listed role requirement is addressed.\n\nTASK TEMPLATE:\n${PLANNER_TEMPLATE_CONTENT}\n\nTASK:\nCreate the plan for the following goal:\n\n${TASK_CONTEXT}"
 
 opencode run "$PLANNER_PROMPT"
 

--- a/templates/task_machine_multirole.md
+++ b/templates/task_machine_multirole.md
@@ -1,0 +1,34 @@
+# Task Machine Template — Multi-Role Project Brief
+
+## Role Descriptions
+
+### Role: Data Analyst
+- Purpose: Interpret quantitative data and transform it into actionable insights.
+- Focus: Accuracy, clarity, measurable impact.
+- Style: Concise, structured, evidence-based.
+
+### Role: Copywriter
+- Purpose: Create clear, engaging, and persuasive text.
+- Focus: Tone, clarity, brand alignment, conversion.
+- Style: Friendly, readable, on-brand.
+
+### Role: Software Architect
+- Purpose: Ensure sound, scalable, and maintainable system design.
+- Focus: Trade-offs, standards, reliability, long-term stability.
+- Style: Precise, technical, structured.
+
+## Tasks
+
+- [ ] Analyze the weekly sales raw data as the **Data Analyst**, producing a concise summary of key findings.
+- [ ] Generate a CSV of aggregated weekly KPIs as the **Data Analyst** and save it to `$OUTPUT_FOLDER/kpi_summary.csv`.
+- [ ] Read the KPI CSV from `$OUTPUT_FOLDER/kpi_summary.csv` as the **Data Analyst** and produce a short interpretation of KPI trends.
+- [ ] Summarize user feedback into key themes as the **Data Analyst**, highlighting recurring patterns across sources.
+- [ ] Create a JSON export of clustered feedback as the **Data Analyst** and save it to `$OUTPUT_FOLDER/feedback_clusters.json`.
+- [ ] Read the clustered feedback JSON from `$OUTPUT_FOLDER/feedback_clusters.json` as the **Data Analyst** and extract the top 5 user pain points.
+- [ ] Write an engaging landing page introduction as the **Copywriter**, optimized for clarity, tone, and conversion.
+- [ ] Draft three alternative hero headlines as the **Copywriter** and save them to `$OUTPUT_FOLDER/headline_options.txt`.
+- [ ] Read the hero headline options from `$OUTPUT_FOLDER/headline_options.txt` as the **Copywriter** and select the strongest variant with justification.
+- [ ] Create a full product description draft as the **Copywriter** and save it to `$OUTPUT_FOLDER/product_description.md`.
+- [ ] Evaluate the new API design as the **Software Architect**, ensuring adherence to architectural principles and scalability.
+- [ ] Produce a system architecture review report as the **Software Architect** and write it to `$OUTPUT_FOLDER/architecture_review.txt`.
+- [ ] Read the architecture review report from `$OUTPUT_FOLDER/architecture_review.txt` as the **Software Architect** and provide a final recommendation summary.


### PR DESCRIPTION
## Summary
- add a reusable multi-role task template that captures the analyst, copywriter, and software architect deliverables
- update the task machine pipeline to require the template and pass its content to the planner so every run follows the predefined tasks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199fa994d0833294907fab36c389c6)