### PR TITLE
Add workflow to run task machine on admin @task requests

### DIFF
--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -79,15 +79,14 @@ jobs:
             jq -r '.comments // [] | map("### Comment by @" + .author + " (" + .createdAt + ")\n\n" + (.body // "") + "\n")[]' output/issue_context.json
           } > output/issue_conversation.md
 
-      - name: Acknowledge @task request with 👀
+      - name: React to @task request with 👀
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         run: |
-          comment_link="https://github.com/$REPOSITORY/issues/$ISSUE_NUMBER#issuecomment-$COMMENT_ID"
           gh api \
             -X POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
-            -f body=$'👀 Noted the @task request here: '"$comment_link"
+            -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
+            "/repos/$REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
+            -f content='eyes'
 
       - name: Install sst/opencode
         if: ${{ steps.admin.outputs.is_admin == 'true' }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that listens for new issue comments containing `@task`
- ensure the workflow only runs for admin-authored comments, acknowledges the request, installs opencode, and executes the task-machine pipeline against the full issue conversation
- automatically commit and push results when files change and respond to the issue with the generated plan

## Testing
- not run (workflow only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b24d210483329c25a40cf3971839)