### PR TITLE
Use context7 without API key

### DIFF
--- a/.github/opencode/config.json
+++ b/.github/opencode/config.json
@@ -1,0 +1,9 @@
+{
+  "mcp": {
+    "context7": {
+      "type": "local",
+      "command": ["npx", "-y", "@upstash/context7-mcp"],
+      "enabled": true
+    }
+  }
+}

--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -94,6 +94,12 @@ jobs:
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
+      - name: Configure opencode
+        if: ${{ steps.admin.outputs.is_admin == 'true' }}
+        run: |
+          mkdir -p "$HOME/.opencode"
+          cp .github/opencode/config.json "$HOME/.opencode/config.json"
+
       - name: Run task machine pipeline
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         env:


### PR DESCRIPTION
## Summary
- update the shared opencode configuration so the context7 MCP integration no longer expects an API key
- simplify the task-machine workflow setup step to copy the shared configuration without attempting to inject a secret

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c23f13e8833286e65cd08aa90ddb)