### PR TITLE
fix: harden task machine opencode install

### DIFF
--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -99,8 +99,19 @@ jobs:
       - name: Install sst/opencode
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         run: |
-          curl -fsSL https://opencode.ai/install | bash
-          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          INSTALL_DIR="$HOME/.opencode/bin"
+          mkdir -p "$INSTALL_DIR"
+
+          TMPDIR="$(mktemp -d)"
+          trap 'rm -rf "$TMPDIR"' EXIT
+          ZIP_PATH="$TMPDIR/opencode.zip"
+
+          curl -fsSL "https://github.com/sst/opencode/releases/latest/download/opencode-linux-x64.zip" -o "$ZIP_PATH"
+          unzip -q "$ZIP_PATH" -d "$TMPDIR"
+          install "$TMPDIR/opencode" "$INSTALL_DIR/opencode"
+
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       - name: Configure opencode
         if: ${{ steps.admin.outputs.is_admin == 'true' }}


### PR DESCRIPTION
## Summary
- replace the curl pipe-to-bash installer in the task machine workflow with a direct download of the latest linux release asset from GitHub
- unzip and install the binary into `$HOME/.opencode/bin` to avoid transient "Failed to fetch version information" errors during the workflow

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d07ead248332a07070cd1775e4a1)