### PR TITLE
Stop using opencode file parameter

### DIFF
--- a/scripts/pipeline_task_machine.sh
+++ b/scripts/pipeline_task_machine.sh
@@ -88,9 +88,9 @@ rm -f "$PLAN_FILE"
 
 echo "Running Task Machine Planner..."
 
-PLANNER_PROMPT="You are the **TASK MACHINE PLANNER** in a two-stage pipeline.\n\nMANDATORY BEHAVIOR:\n- Read the user's high-level goal and constraints from the attached task context file.\n- Produce a markdown document written to: \`${PLAN_FILE}\`.\n- The document MUST contain two sections: \n  1. \`## Context\` summarizing the overall objective.\n  2. \`## Chronologic Task List\` describing step-by-step tasks.\n- Every task MUST be self-contained, independent, and formatted as a markdown checkbox line in chronological order, e.g. \`- [ ] Task name — clear, actionable instructions...\`.\n- Include all details needed to execute each task without referencing other tasks.\n- Do NOT mark any task as completed.\n- You MUST use MCP tools to write the document and MUST NOT finish without creating \`${PLAN_FILE}\`.\n- You MUST incorporate the provided task template verbatim and ensure each listed role requirement is addressed.\n\nTASK TEMPLATE:\n${PLANNER_TEMPLATE_CONTENT}\n\nTASK:\nCreate the plan for the request described in the attached context file: ${CONTEXT_FILE}"
+PLANNER_PROMPT="You are the **TASK MACHINE PLANNER** in a two-stage pipeline.\n\nMANDATORY BEHAVIOR:\n- Read the user's high-level goal and constraints directly from the context file located at \`${CONTEXT_FILE}\`.\n- Produce a markdown document written to: \`${PLAN_FILE}\`.\n- The document MUST contain two sections: \n  1. \`## Context\` summarizing the overall objective.\n  2. \`## Chronologic Task List\` describing step-by-step tasks.\n- Every task MUST be self-contained, independent, and formatted as a markdown checkbox line in chronological order, e.g. \`- [ ] Task name — clear, actionable instructions...\`.\n- Include all details needed to execute each task without referencing other tasks.\n- Do NOT mark any task as completed.\n- You MUST use MCP tools to read \`${CONTEXT_FILE}\`, write the document, and MUST NOT finish without creating \`${PLAN_FILE}\`.\n- You MUST incorporate the provided task template verbatim and ensure each listed role requirement is addressed.\n\nTASK TEMPLATE:\n${PLANNER_TEMPLATE_CONTENT}\n\nTASK:\nCreate the plan for the request described in the context file stored at \`${CONTEXT_FILE}\`."
 
-opencode run --file "$CONTEXT_FILE" -- "$PLANNER_PROMPT"
+opencode run "$PLANNER_PROMPT"
 
 require_file "$PLAN_FILE"
 echo "Planner completed: ${PLAN_FILE}"
@@ -104,9 +104,9 @@ echo "Entering executor loop..."
 iteration=1
 while grep -q "\\[ \\]" "$PLAN_FILE"; do
   echo "Running executor iteration ${iteration}..."
-  EXECUTOR_PROMPT="You are the **TASK MACHINE EXECUTOR**.\n\nMANDATORY BEHAVIOR:\n- Read the shared plan at \`${PLAN_FILE}\`.\n- Identify the FIRST unchecked task (first line containing \`- [ ]\`).\n- Execute ONLY that task. Do not attempt subsequent tasks.\n- After completing the task, update the same line to \`- [x]\` and append a concise summary of what you accomplished, including any outputs or follow-up notes.\n- Do NOT alter other tasks except to add a short inline status note if strictly required by the executed task.\n- Use MCP tools to rewrite the updated plan back to \`${PLAN_FILE}\`.\n- You MUST NOT finish without updating \`${PLAN_FILE}\`.\n- If execution reveals new subtasks, append them as new unchecked tasks immediately after the current line.\n- Keep your console response brief; the authoritative record is the plan file.\n\nTASK:\nComplete only the first open task in the plan."
+  EXECUTOR_PROMPT="You are the **TASK MACHINE EXECUTOR**.\n\nMANDATORY BEHAVIOR:\n- Use MCP tools to read the shared plan at \`${PLAN_FILE}\` before making any edits.\n- Identify the FIRST unchecked task (first line containing \`- [ ]\`).\n- Execute ONLY that task. Do not attempt subsequent tasks.\n- After completing the task, update the same line to \`- [x]\` and append a concise summary of what you accomplished, including any outputs or follow-up notes.\n- Do NOT alter other tasks except to add a short inline status note if strictly required by the executed task.\n- Use MCP tools to rewrite the updated plan back to \`${PLAN_FILE}\`.\n- You MUST NOT finish without updating \`${PLAN_FILE}\`.\n- If execution reveals new subtasks, append them as new unchecked tasks immediately after the current line.\n- Keep your console response brief; the authoritative record is the plan file.\n\nTASK:\nComplete only the first open task in the plan."
 
-  opencode run --file "$PLAN_FILE" -- "$EXECUTOR_PROMPT"
+  opencode run "$EXECUTOR_PROMPT"
 
   require_file "$PLAN_FILE"
   echo "Executor iteration ${iteration} finished."


### PR DESCRIPTION
## Summary
- update the task machine planner prompt to instruct the agent to read the context file directly and drop the `--file` argument
- update the executor loop prompt to require explicit MCP reads of the plan file and remove the `--file` argument when invoking `opencode run`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d58f5a2483328be2ecdf80bc68e4)