### PR TITLE
Print task plan after planner

### DIFF
--- a/scripts/pipeline_task_machine.sh
+++ b/scripts/pipeline_task_machine.sh
@@ -94,6 +94,9 @@ opencode run "$PLANNER_PROMPT"
 
 require_file "$PLAN_FILE"
 echo "Planner completed: ${PLAN_FILE}"
+echo "\n===== Task Plan ====="
+cat "$PLAN_FILE"
+echo "===== End Task Plan =====\n"
 echo ""
 
 #############################################


### PR DESCRIPTION
## Summary
- update the task machine pipeline to dump the generated plan to the console immediately after the planner finishes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919dd6888a88332bf76707ab819ec8f)