### PR TITLE
Persist task machine plan for git detection

### DIFF
--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -130,6 +130,16 @@ jobs:
           fi
           bash scripts/pipeline_task_machine.sh --file "$PROMPT_FILE"
 
+      - name: Persist final plan for git diff
+        if: ${{ steps.admin.outputs.is_admin == 'true' }}
+        env:
+          PLAN_ARCHIVE: .github/task-machine/issue-${{ github.event.issue.number }}.md
+        run: |
+          if [[ -f output/task_machine_plan.md ]]; then
+            mkdir -p "$(dirname "$PLAN_ARCHIVE")"
+            cp output/task_machine_plan.md "$PLAN_ARCHIVE"
+          fi
+
       - name: Detect repository changes
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         id: git-status


### PR DESCRIPTION
## Summary
- copy the generated task machine plan into a tracked location inside `.github/task-machine/` so that the workflow can see a repository diff even though the original plan lives in the ignored `output/` directory
- ensure the new file is written before the change-detection step so the branch creation logic is triggered whenever the plan exists

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919e41273bc833299efd89496100b01)