### PR TITLE
Stop ignoring output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,3 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# Output files
-output/


### PR DESCRIPTION
## Summary
- remove the `output/` entry from `.gitignore` so the directory can be tracked

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919eea04414833292b998e8d0eccff8)