### PR TITLE
Add context7 MCP requirement to task executor

### DIFF
--- a/scripts/pipeline_task_machine.sh
+++ b/scripts/pipeline_task_machine.sh
@@ -200,6 +200,7 @@ MANDATORY BEHAVIOR:
 - Use MCP tools to rewrite the updated plan back to \`${PLAN_FILE}\` before finishing.
 - Keep your console response brief; the authoritative record is the plan file.
 - This workflow is UNSUPERVISED: do not ask questions or seek confirmation—make decisions yourself based solely on the provided task description and files.
+- Whenever you need up-to-date, version-specific library documentation or code examples, query the **context7 MCP server** to gather that information before proceeding.
 
 TASK:
 Complete only the first open task in the plan.


### PR DESCRIPTION
## Summary
- update the task machine executor instructions to require querying the context7 MCP server whenever version-specific library documentation or code samples are needed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7025ec688332bbf5392d0b8755af)