### PR TITLE
Add uv installation to task machine workflow

### DIFF
--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -123,6 +123,13 @@ jobs:
               -f content='eyes'
           fi
 
+      - name: Install uv
+        if: ${{ steps.admin.outputs.is_admin == 'true' }}
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Install sst/opencode
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         run: |


### PR DESCRIPTION
## Summary
- install uv before running the task machine workflow setup
- ensure uv binary directory is added to PATH prior to installing opencode

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0f63af3c8332bc68ca50368fe04f)