### PR TITLE
Add ripgrep installation to task machine workflow

### DIFF
--- a/.github/workflows/task-machine.yml
+++ b/.github/workflows/task-machine.yml
@@ -123,6 +123,13 @@ jobs:
               -f content='eyes'
           fi
 
+      - name: Install ripgrep
+        if: ${{ steps.admin.outputs.is_admin == 'true' }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
       - name: Install uv
         if: ${{ steps.admin.outputs.is_admin == 'true' }}
         run: |


### PR DESCRIPTION
## Summary
- install ripgrep in the task machine GitHub workflow before installing uv to ensure ripgrep is available

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e132078948332951b66792220d9f0)